### PR TITLE
adds some as_date features to make date assignments a little faster

### DIFF
--- a/man/possible_date.Rd
+++ b/man/possible_date.Rd
@@ -14,9 +14,9 @@ unknown_date(
   invalid_date_string = "^UNK?|NA$"
 )
 
-earliest_date(year, month = NULL, day = NULL)
+earliest_date(year, month = NULL, day = NULL, as_date = TRUE)
 
-latest_date(year, month = NULL, day = NULL)
+latest_date(year, month = NULL, day = NULL, as_date = TRUE)
 }
 \arguments{
 \item{x}{a date "string" (see details)}
@@ -33,6 +33,8 @@ to be removed from `x`}
 \item{month}{Month}
 
 \item{day}{Day}
+
+\item{as_date}{Logical, if TRUE will return the output as a date}
 }
 \description{
 Incomplete dates cannot be directly coerced into date values in R.
@@ -47,6 +49,9 @@ If a split vector of 1 is passed to `unknown_date`, it is assumed that the
   vector consists only of the Year.
 For cases in which the year is not provided or the month is unknown, it is
   suggested that these be recoded before using this function.
+
+The `as_date` parameter is used to allow the `unknown_date` function to work
+  with a character vector and change the date class at the end
 }
 \examples{
 earliest_date(2019, 1, 0)


### PR DESCRIPTION
Rewrites large parts of the dates functions to remove redundancies and vectorize a few operations.

```r
x <- c("2019-01-01", "2019-02-28", "2019 UNK 3", "2004 JUN UN", NA, "200 Feb")
x <- sample(x, 100000, TRUE)
microbenchmark::microbenchmark(
  unknown_date(x),
  times = 100
)
```

Updates in pull:
```
 Unit: seconds
             expr      min       lq    mean   median      uq      max neval
  unknown_date(x) 5.434079 5.711711 6.31309 5.910212 6.33507 10.10183   100
```
 
master: (had to limit `times = 10`)
```
 Unit: seconds
             expr      min       lq     mean   median       uq      max neval
  unknown_date(x) 53.92544 87.10585 193.9904 102.0051 133.1174 1027.367    10
```

Performance is much better and all tests pass.

Some updates were needed to remove use of `NULL` values and using defaults of `NA`.  Couldn't think of a good reason to have `NULL` as all functions that funnel in will correctly add `NA` for missing values.